### PR TITLE
Beacon improvements

### DIFF
--- a/Sources/NPGKit/Model+Codable.swift
+++ b/Sources/NPGKit/Model+Codable.swift
@@ -21,31 +21,34 @@ extension NPGBeacon {
 
 extension NPGArea {
     enum CodingKeys: String, CodingKey {
-        case id, title, subtitle, beacon, priority
+        case id, title, subtitle, priority
         case dateModified = "datemodified"
         case locationIDs = "locations"
         case labelIDs = "labels"
+        case beaconID = "beaconid"
     }
 }
 
 extension NPGLocation {
     enum CodingKeys: String, CodingKey {
-        case id, title, subtitle, beacon, priority, audio
+        case id, title, subtitle, priority, audio
         case dateModified = "datemodified"
         case areaID = "areaid"
         case labelIDs = "labels"
+        case beaconID = "beaconid"
     }
 }
 
 extension NPGArtwork {
     enum CodingKeys: String, CodingKey {
-        case id, title, subtitle, beacon, priority, width, height, text, images, audio
+        case id, title, subtitle, priority, width, height, text, images, audio
         case dateModified = "datemodified"
         case dateCreated = "datecreated"
         case areaID = "areaid"
         case locationID = "locationid"
         case nearbyArtworks = "nearbylabels"
         case scanObjects = "3dscan"
+        case beaconID = "beaconid"
     }
 }
 

--- a/Sources/NPGKit/Model+Legacy.swift
+++ b/Sources/NPGKit/Model+Legacy.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/**
+ Legacy support for old attributes
+*/
+extension NPGArea {
+    @available(swift, deprecated: 1.0, renamed: "beaconID")
+    var beacon: String? {
+        guard let beaconID = beaconID else {
+            return nil
+        }
+        return "\(beaconID)"
+    }
+}
+
+extension NPGLocation {
+    @available(swift, deprecated: 1.0, renamed: "beaconID")
+    var beacon: String? {
+        guard let beaconID = beaconID else {
+            return nil
+        }
+        return "\(beaconID)"
+    }
+}
+
+extension NPGArtwork {
+    @available(swift, deprecated: 1.0, renamed: "beaconID")
+    var beacon: String? {
+        guard let beaconID = beaconID else {
+            return nil
+        }
+        return "\(beaconID)"
+    }
+}

--- a/Sources/NPGKit/Model.swift
+++ b/Sources/NPGKit/Model.swift
@@ -106,8 +106,8 @@ public struct NPGArea: NPGObject, Codable {
     /// An optional subtitle for this area.
     public var subtitle: String?
     
-    /// A becaon identifier associated with this area.
-    public var beacon: String?
+    /// A beacon identifier associated with this area.
+    public var beaconID: Int?
     
     /// Sort priority
     public var priority: Int
@@ -141,8 +141,8 @@ public struct NPGLocation: NPGObject, Codable {
     /// An optional text of a label that may appear at the entrance to the space.
     public var content: String?
     
-    /// A becaon identifier associated with this location.
-    public var beacon: String?
+    /// A beacon identifier associated with this location.
+    public var beaconID: Int?
     
     /// Sort priority.
     public var priority: Int
@@ -218,7 +218,7 @@ public struct NPGArtwork: NPGObject, Codable {
     public var locationID: Int?
     
     /// The ID of the beacon associated with this artwork. If empty, use the beacon associated with the area or location.
-    public var beacon: String?
+    public var beaconID: Int?
     
     /// Sort priority. This may be used to passively encourage a particular visitor flow and may not seem to have any logical reason.
     public var priority: Int


### PR DESCRIPTION
Use “beaconID”<Int?> instead of “beacon”<String?> to identify related beacons.