### PR TITLE
Minimum platform versions, Hashable, Identifiable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,19 +5,18 @@ import PackageDescription
 
 let package = Package(
     name: "NPGKit",
+    platforms: [
+            .macOS(.v11),
+            .iOS(.v13)
+        ],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "NPGKit",
             targets: ["NPGKit"]),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "NPGKit",
             dependencies: []),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "NPGKit",
+    platforms: [
+            .macOS(.v11),
+            .iOS(.v13),
+            .visionOS("1.0.0")
+        ],
+    products: [
+        .library(
+            name: "NPGKit",
+            targets: ["NPGKit"]),
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .target(
+            name: "NPGKit",
+            dependencies: []),
+        .testTarget(
+            name: "NPGKitTests",
+            dependencies: ["NPGKit"]),
+    ]
+)

--- a/Sources/NPGKit/Model.swift
+++ b/Sources/NPGKit/Model.swift
@@ -46,7 +46,7 @@ internal enum NPGBool: String, Codable {
 
 // MARK: Public Items
 
-public protocol NPGObject: Equatable {
+public protocol NPGObject: Hashable, Identifiable {
     var id: Int { get }
     var dateModified: Date { get }
 }


### PR DESCRIPTION
Adds minimum platform versions, visionOS support. Also makes NPGObject hashable and identifiable