### PR TITLE
Memberwise inits

### DIFF
--- a/Sources/NPGKit/Model+Codable.swift
+++ b/Sources/NPGKit/Model+Codable.swift
@@ -1,13 +1,5 @@
 import Foundation
 
-extension NPGObject {
-    internal static var dateFormatter: DateFormatter {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-        return dateFormatter
-    }
-}
-
 extension NPGData {
     enum CodingKeys: String, CodingKey {
         case areas, locations, beacons, tours

--- a/Sources/NPGKit/Model+Convenience.swift
+++ b/Sources/NPGKit/Model+Convenience.swift
@@ -1,6 +1,14 @@
 import Foundation
 import SwiftUI
 
+extension NPGObject {
+    internal static var dateFormatter: DateFormatter {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        return dateFormatter
+    }
+}
+
 extension NPGBool {
     init(bool: Bool) {
         self = bool ? .yes : .no

--- a/Sources/NPGKit/Model+Convenience.swift
+++ b/Sources/NPGKit/Model+Convenience.swift
@@ -1,6 +1,12 @@
 import Foundation
 import SwiftUI
 
+public extension Int {
+    static func idGenerator() -> Int {
+        (0..<Int.max).randomElement() ?? 90210
+    }
+}
+
 extension NPGObject {
     internal static var dateFormatter: DateFormatter {
         let dateFormatter = DateFormatter()
@@ -23,23 +29,217 @@ extension NPGMetadata {
     static public let empty = Self.init(title: "", subtitle: "", intro: "")
 }
 
+extension NPGCoordinates {
+    public init(latitude: CGFloat = .zero, longitude: CGFloat = .zero) {
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+}
+
+extension NPGTour {
+    public init(id: Int = .idGenerator(),
+                title: String,
+                subtitle: String? = nil,
+                beaconID: Int? = nil,
+                priority: Int = 1,
+                audio: [NPGAudio],
+                tourStops: [NPGTour.TourStop]) {
+        self.id = id
+        self.dateModified = .now
+        self.title = title
+        self.subtitle = subtitle
+        self.beaconID = beaconID
+        self.priority = priority
+        self.audio = audio
+        self.tourStops = tourStops
+    }
+}
+
+extension NPGTour.TourStop {
+    public init(id: Int = .idGenerator(),
+                title: String,
+                subtitle: String? = nil,
+                content: String? = nil,
+                beaconID: Int,
+                priority: Int = 1,
+                artworkIDs: [Int],
+                audio: [NPGAudio]) {
+        self.id = id
+        self.dateModified = .now
+        self.title = title
+        self.subtitle = subtitle
+        self.content = content
+        self.beaconID = beaconID
+        self.priority = priority
+        self.artworkIDs = artworkIDs
+        self.audio = audio
+    }
+}
+
+extension NPGBeacon {
+    public init(id: Int = .idGenerator(),
+                proximityUUID: UUID,
+                major: Int = 1,
+                minor: Int,
+                title: String,
+                areaIDs: [Int],
+                locationIDs: [Int],
+                artworkIDs: [Int]) {
+        self.id = id
+        self.dateModified = .now
+        self.proximityUUID = proximityUUID
+        self.major = major
+        self.minor = minor
+        self.title = title
+        self.areaIDs = areaIDs
+        self.locationIDs = locationIDs
+        self.artworkIDs = artworkIDs
+    }
+}
+
+extension NPGArea {
+    public init(id: Int = .idGenerator(),
+                title: String,
+                subtitle: String? = nil,
+                beaconIDs: [Int],
+                priority: Int = 1,
+                locationIDs: [Int],
+                artworkIDs: [Int],
+                externalCoordinates: NPGCoordinates? = nil) {
+        self.id = id
+        self.dateModified = .now
+        self.title = title
+        self.subtitle = subtitle
+        self.beaconIDs = beaconIDs
+        self.priority = priority
+        self.locationIDs = locationIDs
+        self.artworkIDs = artworkIDs
+        self.externalCoordinates = externalCoordinates
+    }
+}
+
+extension NPGArea.Location {
+    public init(id: Int = .idGenerator(),
+                areaID: Int,
+                title: String,
+                subtitle: String? = nil,
+                content: String? = nil,
+                beaconID: Int? = nil,
+                priority: Int = 1,
+                artworkIDs: [Int],
+                audio: [NPGAudio]) {
+        self.id = id
+        self.areaID = areaID
+        self.dateModified = .now
+        self.title = title
+        self.subtitle = subtitle
+        self.content = content
+        self.beaconID = beaconID
+        self.priority = priority
+        self.artworkIDs = artworkIDs
+        self.audio = audio
+    }
+}
+
 extension NPGArtwork {
+    public init(id: Int = .idGenerator(),
+                title: String,
+                subtitle: String = "",
+                dateCreated: String,
+                areaID: Int,
+                locationID: Int? = nil,
+                beaconID: Int? = nil,
+                priority: Int = 1,
+                size: CGSize = .zero,
+                text: [NPGArtwork.LabelText] = [],
+                images: [NPGImage] = [],
+                nearbyArtworks: [NPGArtwork.Nearby] = [],
+                audio: [NPGAudio] = [],
+                scanObjects: [NPG3DObject] = []) {
+        self.id = id
+        self.dateModified = .now
+        self.title = title
+        self.subtitle = subtitle
+        self.dateCreated = dateCreated
+        self.areaID = areaID
+        self.locationID = locationID
+        self.beaconID = beaconID
+        self.priority = priority
+        self.width = size.width
+        self.height = size.height
+        self.text = text
+        self.images = images
+        self.nearbyArtworks = nearbyArtworks
+        self.audio = audio
+        self.scanObjects = scanObjects
+    }
+    
     /// The size of the artwork in centimetres.
     public var size: CGSize {
         .init(width: width, height: height)
     }
 }
 
+extension NPGArtwork.LabelText {
+    public init(type: NPGArtwork.LabelText.LabelType = .label,
+                priority: Int = 1,
+                content: String) {
+        self.type = type
+        self.content = content
+        self.priority = priority
+    }
+}
+
+extension NPGArtwork.Nearby {
+    public init(relatedArtworkID: Int,
+                relationship: NPGArtwork.Nearby.Relationship = .near) {
+        self.id = relatedArtworkID
+        self.relationship = relationship
+    }
+}
+
 extension NPGImage {
+    public init(id: Int = .idGenerator(),
+                dateModified: Date = .now,
+                scanningOnly: Bool = false,
+                size: CGSize = .zero,
+                subjectCrop: NPGImage.CropSize? = nil,
+                faceCrops: [NPGImage.FaceCrop] = [],
+                url: URL,
+                thumbnailURL: URL? = nil,
+                squareURL: URL? = nil) {
+        self.id = id
+        self.dateModified = dateModified
+        self.scanningOnly = scanningOnly
+        self.width = size.width
+        self.height = size.height
+        self.subjectCrop = subjectCrop
+        self.faceCrops = faceCrops
+        self.url = url
+        self.thumbnailURL = thumbnailURL
+        self.squareURL = squareURL
+    }
+    
     public var size: CGSize {
         .init(width: width, height: height)
     }
 }
 
+extension NPGImage.FaceCrop {
+    public init(entityID: Int, cropString: String) throws {
+        self.entityID = entityID
+        self.crop = try NPGImage.CropSize(string: cropString)
+    }
+}
+
 extension NPGImage.CropSize {
-    internal init(rect: CGRect) {
-        self.referenceWidth = 100
-        self.referenceHeight = 100
+    public static func defaultCrop() -> Self {
+        .init(rect: .init(origin: .init(x: 50, y: 50), size: .init(width: 50, height: 50)))
+    }
+    
+    public init(rect: CGRect, referenceSize: CGSize = .init(width: 100, height: 100)) {
+        self.referenceWidth = referenceSize.width
+        self.referenceHeight = referenceSize.height
         
         self.topLeftX = rect.origin.x / referenceWidth
         self.topLeftY = rect.origin.y / referenceHeight
@@ -125,5 +325,60 @@ extension NPGImage.CropSize {
         let origin = CGPoint(x: topLeft.x * outputSize.width, y: topLeft.y * outputSize.height)
         
         return .init(origin: origin, size: size)
+    }
+}
+
+extension NPGAudio {
+    public init(id: Int = .idGenerator(),
+                priority: Int = 1,
+                audioContext: NPGAudio.AudioContext = .audiodescription,
+                title: String,
+                duration: String,
+                transcript: String,
+                attribution: String? = nil,
+                acknowledgements: String? = nil,
+                url: URL) {
+        self.id = id
+        self.dateModified = .now
+        self.priority = priority
+        self.audioContext = audioContext
+        self.title = title
+        self.duration = duration
+        self.transcript = transcript
+        self.attribution = attribution
+        self.acknowledgements = acknowledgements
+        self.url = url
+    }
+}
+
+extension NPG3DObject {
+    public init(id: Int = .idGenerator(),
+                url: URL) {
+        self.id = id
+        self.dateModified = .now
+        self.url = url
+    }
+}
+
+extension NPGEntity {
+    public init(id: Int = .idGenerator(),
+                displayName: String,
+                simpleName: String? = nil,
+                givenNames: [String]? = nil,
+                familyNames: [String]? = nil,
+                text: [NPGArtwork.LabelText] = [],
+                audio: [NPGAudio] = [],
+                artworkAsSubjectIDs: [Int] = [],
+                artworkAsArtistIDs: [Int] = []) {
+        self.id = id
+        self.dateModified = .now
+        self.displayName = displayName
+        self.simpleName = simpleName
+        self.givenNames = givenNames
+        self.familyNames = familyNames
+        self.text = text
+        self.audio = audio
+        self.artworkAsSubjectIDs = artworkAsSubjectIDs
+        self.artworkAsArtistIDs = artworkAsArtistIDs
     }
 }

--- a/Sources/NPGKit/Model.swift
+++ b/Sources/NPGKit/Model.swift
@@ -72,16 +72,17 @@ public struct NPGCoordinates: Hashable, Codable, Sendable {
  NPGTour represents a self-guided tour or pre-determined path through the gallery.
  */
 public struct NPGTour: NPGObject, Codable {
-    public init(id: Int, dateModified: Date, title: String, subtitle: String? = nil, beaconID: Int? = nil, priority: Int, audio: [NPGAudio], tourStops: [NPGTour.TourStop]) {
-        self.id = id
-        self.dateModified = dateModified
-        self.title = title
-        self.subtitle = subtitle
-        self.beaconID = beaconID
-        self.priority = priority
-        self.audio = audio
-        self.tourStops = tourStops
-    }
+    
+    /**
+     TourStop represents a particular stop on an ``NPGTour``.
+     */
+    public struct TourStop: NPGObject, Codable {
+        /// A unique identifier for this tour stop.
+        public var id: Int
+        
+        /// Last modified date for this tour stop..
+        public var dateModified: Date
+        
         /// The name of the tour stop.
         public var title: String
         
@@ -133,18 +134,6 @@ public struct NPGTour: NPGObject, Codable {
  NPGBeacon represents a physical iBeacon within the gallery.
  */
 public struct NPGBeacon: NPGObject, Codable {
-    public init(id: Int, dateModified: Date, proximityUUID: UUID, major: Int, minor: Int, title: String, areaIDs: [Int], locationIDs: [Int], artworkIDs: [Int]) {
-        self.id = id
-        self.dateModified = dateModified
-        self.proximityUUID = proximityUUID
-        self.major = major
-        self.minor = minor
-        self.title = title
-        self.areaIDs = areaIDs
-        self.locationIDs = locationIDs
-        self.artworkIDs = artworkIDs
-    }
-    
     
     /// A unique identifier for this beacon.
     public var id: Int
@@ -180,35 +169,11 @@ public struct NPGBeacon: NPGObject, Codable {
  For example, the area for Portrait 23 encompasses the locations "Gallery 4", "Gallery 5", "Gallery 6", "Gallery 6 Nook 1" and "Gallery 6 Nook 2".
  */
 public struct NPGArea: NPGObject, Codable {
-    public init(id: Int, dateModified: Date, title: String, subtitle: String? = nil, beaconIDs: [Int], priority: Int, locationIDs: [Int], artworkIDs: [Int], externalCoordinates: NPGCoordinates? = nil) {
-        self.id = id
-        self.dateModified = dateModified
-        self.title = title
-        self.subtitle = subtitle
-        self.beaconIDs = beaconIDs
-        self.priority = priority
-        self.locationIDs = locationIDs
-        self.artworkIDs = artworkIDs
-        self.externalCoordinates = externalCoordinates
-    }
     
     /**
      NPGArea.Location represents a given contiguous area within the Gallery. This might be an entire Gallery space (i.e. Gallery 2), an alcove, or even a wall.
      */
     public struct Location: NPGObject, Codable {
-        public init(id: Int, areaID: Int, dateModified: Date, title: String, subtitle: String? = nil, content: String? = nil, beaconID: Int? = nil, priority: Int, artworkIDs: [Int], audio: [NPGAudio]) {
-            self.id = id
-            self.areaID = areaID
-            self.dateModified = dateModified
-            self.title = title
-            self.subtitle = subtitle
-            self.content = content
-            self.beaconID = beaconID
-            self.priority = priority
-            self.artworkIDs = artworkIDs
-            self.audio = audio
-        }
-        
         /// A unique identifier for this location.
         public var id: Int
         
@@ -273,25 +238,6 @@ public struct NPGArea: NPGObject, Codable {
  It includes the name and description of the artwork along with images, 3D objects (for scanning), and audio files describing the work or as an interview with the artist or sitter.
  */
 public struct NPGArtwork: NPGObject, Codable {
-    public init(id: Int, dateModified: Date, title: String, subtitle: String, dateCreated: String, areaID: Int, locationID: Int? = nil, beaconID: Int? = nil, priority: Int, width: Double, height: Double, text: [NPGArtwork.LabelText], images: [NPGImage], nearbyArtworks: [NPGArtwork.Nearby], audio: [NPGAudio], scanObjects: [NPG3DObject]) {
-        self.id = id
-        self.dateModified = dateModified
-        self.title = title
-        self.subtitle = subtitle
-        self.dateCreated = dateCreated
-        self.areaID = areaID
-        self.locationID = locationID
-        self.beaconID = beaconID
-        self.priority = priority
-        self.width = width
-        self.height = height
-        self.text = text
-        self.images = images
-        self.nearbyArtworks = nearbyArtworks
-        self.audio = audio
-        self.scanObjects = scanObjects
-    }
-    
     
     /// Text used for an artwork's on-wall label.
     public struct LabelText: Codable, Hashable, Sendable {
@@ -381,19 +327,6 @@ public struct NPGArtwork: NPGObject, Codable {
 
 /// An image file representing an artwork.
 public struct NPGImage: NPGFile {
-    public init(id: Int, dateModified: Date, scanningOnly: Bool, width: Double, height: Double, subjectCrop: NPGImage.CropSize? = nil, faceCrops: [NPGImage.FaceCrop], url: URL, thumbnailURL: URL? = nil, squareURL: URL? = nil) {
-        self.id = id
-        self.dateModified = dateModified
-        self.scanningOnly = scanningOnly
-        self.width = width
-        self.height = height
-        self.subjectCrop = subjectCrop
-        self.faceCrops = faceCrops
-        self.url = url
-        self.thumbnailURL = thumbnailURL
-        self.squareURL = squareURL
-    }
-    
     /**
      A structure dictating how an image should be cropped. If no reference size is supplied (or is zero), it should be assumed that the topLeft and and bottomRight are percentage values of the image's total size.
      
@@ -410,11 +343,6 @@ public struct NPGImage: NPGFile {
     
     /// A structure specifying the region of a person's face within an image
     public struct FaceCrop: Hashable, Sendable {
-        public init(entityID: Int, crop: NPGImage.CropSize) {
-            self.entityID = entityID
-            self.crop = crop
-        }
-        
         public var entityID: Int
         public var crop: CropSize
     }
@@ -454,18 +382,6 @@ public struct NPGImage: NPGFile {
 
 /// An audio file associated with an artwork.
 public struct NPGAudio: NPGFile, Codable, Sendable {
-    public init(id: Int, dateModified: Date, priority: Int, audioContext: NPGAudio.AudioContext, title: String, duration: String, transcript: String, attribution: String? = nil, acknowledgements: String? = nil, url: URL) {
-        self.id = id
-        self.dateModified = dateModified
-        self.priority = priority
-        self.audioContext = audioContext
-        self.title = title
-        self.duration = duration
-        self.transcript = transcript
-        self.attribution = attribution
-        self.acknowledgements = acknowledgements
-        self.url = url
-    }
     
     /// The context in which an audio file should be used.
     public enum AudioContext: String, Equatable, Codable, Sendable {
@@ -515,11 +431,6 @@ public struct NPGAudio: NPGFile, Codable, Sendable {
 
 /// An 3D scan associated with an artwork.
 public struct NPG3DObject: NPGFile, Codable {
-    public init(id: Int, dateModified: Date, url: URL) {
-        self.id = id
-        self.dateModified = dateModified
-        self.url = url
-    }
     
     /// The unique identifier of our file.
     public var id: Int
@@ -537,19 +448,6 @@ public struct NPG3DObject: NPGFile, Codable {
  Note that as of 1.0.8 these entities **are not** being retrieved, and instead are a proposed structure for future implmentation.
  */
 public struct NPGEntity: NPGObject, Codable {
-    public init(id: Int, dateModified: Date, displayName: String, simpleName: String? = nil, givenNames: [String]? = nil, familyNames: [String]? = nil, text: [NPGArtwork.LabelText], audio: [NPGAudio], artworkAsSubjectIDs: [Int], artworkAsArtistIDs: [Int]) {
-        self.id = id
-        self.dateModified = dateModified
-        self.displayName = displayName
-        self.simpleName = simpleName
-        self.givenNames = givenNames
-        self.familyNames = familyNames
-        self.text = text
-        self.audio = audio
-        self.artworkAsSubjectIDs = artworkAsSubjectIDs
-        self.artworkAsArtistIDs = artworkAsArtistIDs
-    }
-    
     
     /// A unique identifier for this entity.
     public var id: Int

--- a/Sources/NPGKit/Model.swift
+++ b/Sources/NPGKit/Model.swift
@@ -72,16 +72,16 @@ public struct NPGCoordinates: Hashable, Codable, Sendable {
  NPGTour represents a self-guided tour or pre-determined path through the gallery.
  */
 public struct NPGTour: NPGObject, Codable {
-    /**
-     TourStop represents a particular stop on an ``NPGTour``.
-     */
-    public struct TourStop: NPGObject, Codable {
-        /// A unique identifier for this tour stop.
-        public var id: Int
-        
-        /// Last modified date for this tour stop..
-        public var dateModified: Date
-        
+    public init(id: Int, dateModified: Date, title: String, subtitle: String? = nil, beaconID: Int? = nil, priority: Int, audio: [NPGAudio], tourStops: [NPGTour.TourStop]) {
+        self.id = id
+        self.dateModified = dateModified
+        self.title = title
+        self.subtitle = subtitle
+        self.beaconID = beaconID
+        self.priority = priority
+        self.audio = audio
+        self.tourStops = tourStops
+    }
         /// The name of the tour stop.
         public var title: String
         
@@ -133,6 +133,18 @@ public struct NPGTour: NPGObject, Codable {
  NPGBeacon represents a physical iBeacon within the gallery.
  */
 public struct NPGBeacon: NPGObject, Codable {
+    public init(id: Int, dateModified: Date, proximityUUID: UUID, major: Int, minor: Int, title: String, areaIDs: [Int], locationIDs: [Int], artworkIDs: [Int]) {
+        self.id = id
+        self.dateModified = dateModified
+        self.proximityUUID = proximityUUID
+        self.major = major
+        self.minor = minor
+        self.title = title
+        self.areaIDs = areaIDs
+        self.locationIDs = locationIDs
+        self.artworkIDs = artworkIDs
+    }
+    
     
     /// A unique identifier for this beacon.
     public var id: Int
@@ -168,10 +180,35 @@ public struct NPGBeacon: NPGObject, Codable {
  For example, the area for Portrait 23 encompasses the locations "Gallery 4", "Gallery 5", "Gallery 6", "Gallery 6 Nook 1" and "Gallery 6 Nook 2".
  */
 public struct NPGArea: NPGObject, Codable {
+    public init(id: Int, dateModified: Date, title: String, subtitle: String? = nil, beaconIDs: [Int], priority: Int, locationIDs: [Int], artworkIDs: [Int], externalCoordinates: NPGCoordinates? = nil) {
+        self.id = id
+        self.dateModified = dateModified
+        self.title = title
+        self.subtitle = subtitle
+        self.beaconIDs = beaconIDs
+        self.priority = priority
+        self.locationIDs = locationIDs
+        self.artworkIDs = artworkIDs
+        self.externalCoordinates = externalCoordinates
+    }
+    
     /**
      NPGArea.Location represents a given contiguous area within the Gallery. This might be an entire Gallery space (i.e. Gallery 2), an alcove, or even a wall.
      */
     public struct Location: NPGObject, Codable {
+        public init(id: Int, areaID: Int, dateModified: Date, title: String, subtitle: String? = nil, content: String? = nil, beaconID: Int? = nil, priority: Int, artworkIDs: [Int], audio: [NPGAudio]) {
+            self.id = id
+            self.areaID = areaID
+            self.dateModified = dateModified
+            self.title = title
+            self.subtitle = subtitle
+            self.content = content
+            self.beaconID = beaconID
+            self.priority = priority
+            self.artworkIDs = artworkIDs
+            self.audio = audio
+        }
+        
         /// A unique identifier for this location.
         public var id: Int
         
@@ -236,6 +273,25 @@ public struct NPGArea: NPGObject, Codable {
  It includes the name and description of the artwork along with images, 3D objects (for scanning), and audio files describing the work or as an interview with the artist or sitter.
  */
 public struct NPGArtwork: NPGObject, Codable {
+    public init(id: Int, dateModified: Date, title: String, subtitle: String, dateCreated: String, areaID: Int, locationID: Int? = nil, beaconID: Int? = nil, priority: Int, width: Double, height: Double, text: [NPGArtwork.LabelText], images: [NPGImage], nearbyArtworks: [NPGArtwork.Nearby], audio: [NPGAudio], scanObjects: [NPG3DObject]) {
+        self.id = id
+        self.dateModified = dateModified
+        self.title = title
+        self.subtitle = subtitle
+        self.dateCreated = dateCreated
+        self.areaID = areaID
+        self.locationID = locationID
+        self.beaconID = beaconID
+        self.priority = priority
+        self.width = width
+        self.height = height
+        self.text = text
+        self.images = images
+        self.nearbyArtworks = nearbyArtworks
+        self.audio = audio
+        self.scanObjects = scanObjects
+    }
+    
     
     /// Text used for an artwork's on-wall label.
     public struct LabelText: Codable, Hashable, Sendable {
@@ -325,6 +381,19 @@ public struct NPGArtwork: NPGObject, Codable {
 
 /// An image file representing an artwork.
 public struct NPGImage: NPGFile {
+    public init(id: Int, dateModified: Date, scanningOnly: Bool, width: Double, height: Double, subjectCrop: NPGImage.CropSize? = nil, faceCrops: [NPGImage.FaceCrop], url: URL, thumbnailURL: URL? = nil, squareURL: URL? = nil) {
+        self.id = id
+        self.dateModified = dateModified
+        self.scanningOnly = scanningOnly
+        self.width = width
+        self.height = height
+        self.subjectCrop = subjectCrop
+        self.faceCrops = faceCrops
+        self.url = url
+        self.thumbnailURL = thumbnailURL
+        self.squareURL = squareURL
+    }
+    
     /**
      A structure dictating how an image should be cropped. If no reference size is supplied (or is zero), it should be assumed that the topLeft and and bottomRight are percentage values of the image's total size.
      
@@ -341,6 +410,11 @@ public struct NPGImage: NPGFile {
     
     /// A structure specifying the region of a person's face within an image
     public struct FaceCrop: Hashable, Sendable {
+        public init(entityID: Int, crop: NPGImage.CropSize) {
+            self.entityID = entityID
+            self.crop = crop
+        }
+        
         public var entityID: Int
         public var crop: CropSize
     }
@@ -380,6 +454,19 @@ public struct NPGImage: NPGFile {
 
 /// An audio file associated with an artwork.
 public struct NPGAudio: NPGFile, Codable, Sendable {
+    public init(id: Int, dateModified: Date, priority: Int, audioContext: NPGAudio.AudioContext, title: String, duration: String, transcript: String, attribution: String? = nil, acknowledgements: String? = nil, url: URL) {
+        self.id = id
+        self.dateModified = dateModified
+        self.priority = priority
+        self.audioContext = audioContext
+        self.title = title
+        self.duration = duration
+        self.transcript = transcript
+        self.attribution = attribution
+        self.acknowledgements = acknowledgements
+        self.url = url
+    }
+    
     /// The context in which an audio file should be used.
     public enum AudioContext: String, Equatable, Codable, Sendable {
         /// An interview with the subject or artist, usually contemporaneous to the associated artwork.
@@ -428,6 +515,12 @@ public struct NPGAudio: NPGFile, Codable, Sendable {
 
 /// An 3D scan associated with an artwork.
 public struct NPG3DObject: NPGFile, Codable {
+    public init(id: Int, dateModified: Date, url: URL) {
+        self.id = id
+        self.dateModified = dateModified
+        self.url = url
+    }
+    
     /// The unique identifier of our file.
     public var id: Int
     
@@ -444,6 +537,19 @@ public struct NPG3DObject: NPGFile, Codable {
  Note that as of 1.0.8 these entities **are not** being retrieved, and instead are a proposed structure for future implmentation.
  */
 public struct NPGEntity: NPGObject, Codable {
+    public init(id: Int, dateModified: Date, displayName: String, simpleName: String? = nil, givenNames: [String]? = nil, familyNames: [String]? = nil, text: [NPGArtwork.LabelText], audio: [NPGAudio], artworkAsSubjectIDs: [Int], artworkAsArtistIDs: [Int]) {
+        self.id = id
+        self.dateModified = dateModified
+        self.displayName = displayName
+        self.simpleName = simpleName
+        self.givenNames = givenNames
+        self.familyNames = familyNames
+        self.text = text
+        self.audio = audio
+        self.artworkAsSubjectIDs = artworkAsSubjectIDs
+        self.artworkAsArtistIDs = artworkAsArtistIDs
+    }
+    
     
     /// A unique identifier for this entity.
     public var id: Int


### PR DESCRIPTION
Codable declaration removes public facing memberwise inits; This PR adds (slightly more convenient) memberwise inits back so we’re able to handcraft local NPG models… for some reason.